### PR TITLE
Fix chat message title

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -370,8 +370,8 @@ async def post_to_chat_webhook(data: dict):
             "cardId": f"store-summary-{store_name.replace(' ', '-')}",
             "card": {
                 "header": {
-                    "title": f"Amazon Metrics Report Monday: Day so far upto {runtime}",
-                    "subtitle": timestamp,
+                    "title": f"Amazon Metrics - {store_name}",
+                    "subtitle": f"{timestamp} | Up to {runtime}",
                     "imageUrl": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
                     "imageType": "CIRCLE"
                 },
@@ -429,8 +429,8 @@ async def post_summary_webhook(data: dict):
             "cardId": f"store-summary-{store_name.replace(' ', '-')}-overall",
             "card": {
                 "header": {
-                    "title": f"Amazon Metrics Report Monday: Day so far upto {runtime}",
-                    "subtitle": timestamp,
+                    "title": f"Amazon Metrics - {store_name}",
+                    "subtitle": f"{timestamp} | Up to {runtime}",
                     "imageUrl": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
                     "imageType": "CIRCLE"
                 },


### PR DESCRIPTION
## Summary
- shorten chat card title
- move timestamp into subtitle so the title isn't truncated

## Testing
- `python -m py_compile scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6863f24ee9908321a1d4b787071febd9