### PR TITLE
Add tests for utils

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import asyncio
+import inspect
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "asyncio: mark async test")
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    if inspect.iscoroutinefunction(pyfuncitem.function):
+        kwargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+        asyncio.run(pyfuncitem.obj(**kwargs))
+        return True

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,61 @@
+import importlib.util
+import sys
+import json
+from pathlib import Path
+import types
+from zoneinfo import ZoneInfo
+import pytest
+
+@pytest.fixture
+def scraper_module(tmp_path, monkeypatch):
+    """Import scraper.py with a temporary config.json."""
+    root_dir = Path(__file__).resolve().parents[1]
+    config = {
+        "debug": False,
+        "login_url": "https://example.com/login",
+        "login_email": "user",
+        "login_password": "pass",
+        "otp_secret_key": "secret",
+        "target_store": {"merchant_id": "1", "marketplace_id": "1", "store_name": "Test"}
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    monkeypatch.chdir(tmp_path)
+
+    # Provide minimal stand-ins for missing third-party modules
+    fake_pytz = types.ModuleType("pytz")
+    fake_pytz.timezone = ZoneInfo
+    fake_pyotp = types.ModuleType("pyotp")
+    class DummyTOTP:
+        def __init__(self, *a, **k):
+            pass
+        def now(self):
+            return "000000"
+    fake_pyotp.TOTP = DummyTOTP
+    fake_playwright = types.ModuleType("playwright")
+    fake_async_api = types.ModuleType("playwright.async_api")
+    fake_async_api.async_playwright = lambda: None
+    fake_async_api.Browser = object
+    fake_async_api.BrowserContext = object
+    fake_async_api.Page = object
+    fake_async_api.TimeoutError = Exception
+    fake_async_api.expect = lambda *a, **k: None
+    fake_playwright.async_api = fake_async_api
+
+    for name, mod in {
+        "pytz": fake_pytz,
+        "pyotp": fake_pyotp,
+        "playwright": fake_playwright,
+        "playwright.async_api": fake_async_api,
+        "aiohttp": types.ModuleType("aiohttp"),
+        "aiofiles": types.ModuleType("aiofiles"),
+        "certifi": types.ModuleType("certifi"),
+    }.items():
+        sys.modules.setdefault(name, mod)
+
+    spec = importlib.util.spec_from_file_location("scraper", root_dir / "scraper.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["scraper"] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop("scraper", None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+import os
+import json
+import pytest
+
+from test_formatting import scraper_module
+
+
+def test_ensure_storage_state_absent(tmp_path, monkeypatch, scraper_module):
+    path = tmp_path / "state.json"
+    monkeypatch.setattr(scraper_module, "STORAGE_STATE", str(path))
+    assert scraper_module.ensure_storage_state() is False
+
+
+def test_ensure_storage_state_invalid_json(tmp_path, monkeypatch, scraper_module):
+    path = tmp_path / "state.json"
+    path.write_text("{invalid")
+    monkeypatch.setattr(scraper_module, "STORAGE_STATE", str(path))
+    assert scraper_module.ensure_storage_state() is False
+
+
+def test_ensure_storage_state_valid(tmp_path, monkeypatch, scraper_module):
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({"cookies": [1]}))
+    monkeypatch.setattr(scraper_module, "STORAGE_STATE", str(path))
+    assert bool(scraper_module.ensure_storage_state()) is True
+
+
+class DummyPage:
+    def __init__(self):
+        self.called = []
+        self.closed = False
+
+    def is_closed(self):
+        return self.closed
+
+    async def screenshot(self, path, full_page=True, timeout=15000):
+        self.called.append(path)
+
+
+@pytest.mark.asyncio
+async def test_save_screenshot(tmp_path, monkeypatch, scraper_module):
+    dummy = DummyPage()
+    monkeypatch.setattr(scraper_module, "OUTPUT_DIR", str(tmp_path))
+    prefix = "testprefix"
+    await scraper_module._save_screenshot(dummy, prefix)
+    assert len(dummy.called) == 1
+    saved = dummy.called[0]
+    assert os.path.commonpath([saved, str(tmp_path)]) == str(tmp_path)
+    assert os.path.basename(saved).startswith(prefix + "_")


### PR DESCRIPTION
## Summary
- add fixture to safely import `scraper.py`
- test `ensure_storage_state` with temporary files
- test `_save_screenshot` using a dummy page
- support asyncio tests with a small conftest plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686421271f888321b2508b0816d94b67