### PR TITLE
Improve debugging screenshot location

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -265,14 +265,15 @@ async def scrape_store_data(browser: Browser, store_info: dict, storage_state: d
             app_logger.info("Dashboard is ready.")
 
             # STEP 2: Click the "Customised" tab via your precise CSS selector
-            customised_tab = page.locator(
-                "#content > div > div.mainAppContainerExternal > div.paddingTop "
-                "> div > div > div > div > span:nth-child(4)"
-            )
+            customised_tab = page.get_by_text("Customised")
             await expect(customised_tab).to_be_visible(timeout=WAIT_TIMEOUT)
             await customised_tab.scroll_into_view_if_needed(timeout=ACTION_TIMEOUT)
             await customised_tab.click(timeout=ACTION_TIMEOUT)
             app_logger.info("Clicked 'Customised' tab.")
+            # Capture a screenshot immediately after clicking the tab to help
+            # diagnose issues where the date picker fails to appear. Previously
+            # the saved screenshot showed the page before this click occurred.
+            await _save_screenshot(page, f"{store_name}_after_customised")
 
             # STEP 3: Wait for the date-range picker to appear
             date_picker = page.locator("kat-date-range-picker")


### PR DESCRIPTION
## Summary
- capture a screenshot right after the `Customised` tab is clicked to help debug missing date picker
- use a text-based locator so clicking the `Customised` tab is more reliable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888aec5825483218bd6e31f2c7f34b2